### PR TITLE
Preprocessor stringify #

### DIFF
--- a/src/data/error.rs
+++ b/src/data/error.rs
@@ -502,6 +502,10 @@ pub enum CppError {
     /// original.
     #[error("redefinition of '{0}' does not match original definition")]
     IncompatibleRedefinition(InternedStr),
+
+    /// '#' in a function macro not followed by function parameter
+    #[error("'#' is not followed by a macro parameter")]
+    HashMissingParameter,
 }
 
 /// Lex errors are non-exhaustive and may have new variants added at any time

--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -1770,22 +1770,31 @@ h",
             .join("");
         assert_eq!(cpp, "\nf");
     }
+    fn assert_same_stringified(cpp: &str, cpp_src: &str) {
+        assert_same_exact(
+            &format!("#define xstr(a) #a\nxstr({})", cpp),
+            &format!("\n{}", cpp_src),
+        );
+    }
     #[test]
-    fn preprocess_stringify() {
-        let assert_same_stringified = |cpp: &str, cpp_src: &str| {
-            assert_same_exact(
-                &format!("#define xstr(a) #a\nxstr({})", cpp),
-                &format!("\n{}", cpp_src),
-            );
-        };
+    fn stringify() {
         assert_same_stringified("a + b", r#""a + b""#);
         assert_same_stringified(r#"b   	 +"c""#, r#""b +\"c\"""#);
         assert_same_stringified(r#""+\\+\n+\"+""#, r#""\"+\\\\+\\n+\\\"+\"""#);
-        assert_same_stringified(r#""\'""#, r#""\"\\'\""#);
+        assert_same_exact("#define xstr(a, b) #a = b\nxstr(1+2,3)", "\n\"1+2\" = 3");
+        assert_same_exact("#define xstr(a, b) a b\nxstr(1+2,3)", "\n1+2 3");
+        assert_same_exact("#define xstr(a) # a\nxstr(1+2)", "\n\"1+2\"");
+        assert_same_exact("#define hash #a\nhash", "\n#a");
+    }
+    #[test]
+    #[ignore = "Depends on #384"]
+    fn stringify_string() {
+        assert_same_stringified(r#""\'""#, r#""\"\\'\"""#);
         assert_same_stringified(
             r#""\a+\b+\e+\f+\r+\v+\?""#,
             r#""\"\\a+\\b+\\e+\\f+\\r+\\v+\\?\"""#,
         );
         assert_same_stringified(r#""\x3f""#, r#""\"\\x3f\"""#);
+        assert_same_stringified(r#""\xff""#, r#""\"\\xff\"""#);
     }
 }

--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -1770,4 +1770,17 @@ h",
             .join("");
         assert_eq!(cpp, "\nf");
     }
+    #[test]
+    fn preprocess_stringify() {
+        let assert_same_stringified = |cpp: &str, cpp_src: &str| {
+            assert_same_exact(
+                &format!("#define xstr(a) #a\nxstr({})", cpp),
+                &format!("\n{}", cpp_src));
+        };
+        assert_same_stringified("a + b", r#""a + b""#);
+        assert_same_stringified(r#"b   	 +"c""#, r#""b +\"c\"""#);
+        assert_same_stringified(r#""+\\+\n+\"+""#, r#""\"+\\\\+\\n+\\\"+\"""#);
+        assert_same_stringified(r#""\'""#, r#""\"\\'\""#);  // TODO figure out why ' is different
+        // TODO test unicode chars
+    }
 }

--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -1694,7 +1694,7 @@ int main(){}
         assert_unchanged("int \t\n\r     main() {}");
         assert_same_exact("int/* */main() {}", "int main() {}");
         assert_same_exact("int/*\n\n\n*/main() {}", "int\n\n\nmain() {}");
-        assert_same_exact("#define a(c) c\tc\na(1);a(2)", "\n1\t1;2\t2");
+        assert_same_exact("#define a(c) c\tc\na(1);a(2)", "\n1 1;2 2");
         assert_same_exact("#define a //\n#if defined a\n  x\n#endif", "\n\n  x\n");
         assert_same_exact("#define x\n#undef x\n  x", "\n\n  x");
         assert_same_exact("#pragma once\n  x", "\n  x");

--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -1787,7 +1787,6 @@ h",
         assert_same_exact("#define hash #a\nhash", "\n#a");
     }
     #[test]
-    #[ignore = "Depends on #384"]
     fn stringify_string() {
         assert_same_stringified(r#""\'""#, r#""\"\\'\"""#);
         assert_same_stringified(

--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -1785,15 +1785,18 @@ h",
         assert_same_exact("#define xstr(a, b) a b\nxstr(1+2,3)", "\n1+2 3");
         assert_same_exact("#define xstr(a) # a\nxstr(1+2)", "\n\"1+2\"");
         assert_same_exact("#define hash #a\nhash", "\n#a");
-    }
-    #[test]
-    fn stringify_string() {
+
         assert_same_stringified(r#""\'""#, r#""\"\\'\"""#);
+        assert_same_stringified(r#""	""#, r#""\"	\"""#); // Tab in string should be maintained
         assert_same_stringified(
             r#""\a+\b+\e+\f+\r+\v+\?""#,
             r#""\"\\a+\\b+\\e+\\f+\\r+\\v+\\?\"""#,
         );
         assert_same_stringified(r#""\x3f""#, r#""\"\\x3f\"""#);
         assert_same_stringified(r#""\xff""#, r#""\"\\xff\"""#);
+
+        assert_same_stringified(r#"'\n'"#, r#""'\\n'""#);
+        assert_same_stringified(r#"  a +   b"#, r#""a + b""#);
+        assert_same_stringified("", r#""""#);
     }
 }

--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -1775,12 +1775,17 @@ h",
         let assert_same_stringified = |cpp: &str, cpp_src: &str| {
             assert_same_exact(
                 &format!("#define xstr(a) #a\nxstr({})", cpp),
-                &format!("\n{}", cpp_src));
+                &format!("\n{}", cpp_src),
+            );
         };
         assert_same_stringified("a + b", r#""a + b""#);
         assert_same_stringified(r#"b   	 +"c""#, r#""b +\"c\"""#);
         assert_same_stringified(r#""+\\+\n+\"+""#, r#""\"+\\\\+\\n+\\\"+\"""#);
-        assert_same_stringified(r#""\'""#, r#""\"\\'\""#);  // TODO figure out why ' is different
-        // TODO test unicode chars
+        assert_same_stringified(r#""\'""#, r#""\"\\'\""#);
+        assert_same_stringified(
+            r#""\a+\b+\e+\f+\r+\v+\?""#,
+            r#""\"\\a+\\b+\\e+\\f+\\r+\\v+\\?\"""#,
+        );
+        assert_same_stringified(r#""\x3f""#, r#""\"\\x3f\"""#);
     }
 }

--- a/src/lex/replace.rs
+++ b/src/lex/replace.rs
@@ -374,7 +374,8 @@ fn stringify(args: Vec<Token>) -> Token {
                     let new_s = std::str::from_utf8(&s)
                         .unwrap()
                         .trim_end_matches('\u{0}')  // remove null terminator
-                        .escape_default();
+                        .escape_default()  // Escape whitespace, etc
+                        .flat_map(char::escape_default); // Escape a second time
                     "\\\"" // Wrap with escaped quotation marks
                         .chars()
                         .chain(new_s)

--- a/src/lex/replace.rs
+++ b/src/lex/replace.rs
@@ -277,9 +277,11 @@ fn replace_function(
         if matches!(args.last(), Some(Token::Whitespace(_))) {
             args.pop();
         }
+        assert!(!matches!(args.last(), Some(Token::Whitespace(_))));
         if matches!(args.first(), Some(Token::Whitespace(_))) {
             args.remove(0);
         }
+        assert!(!matches!(args.first(), Some(Token::Whitespace(_))));
         args
     }
 

--- a/src/lex/replace.rs
+++ b/src/lex/replace.rs
@@ -373,27 +373,24 @@ fn replace_function(
 }
 
 fn stringify(args: Vec<Token>) -> Token {
+    let escape = |s: &str| s.replace('\\', "\\\\").replace('"', "\\\"");
     let ret: String = args
         .into_iter()
         .map(|arg| {
             match arg {
                 Token::Whitespace(_) => String::from(" "), // Single space in replacement
-                Token::Literal(LiteralToken::Str(rcstrs)) => {
-                    rcstrs
-                        .iter()
-                        .map(|rcstr| {
-                            rcstr
-                                .as_str()
-                                .escape_default()
-                                .collect::<String>()
-                                .replace(r#"\'"#, "'") // Because Rust escapes ' but C does not
-                        })
-                        .collect::<Vec<_>>()
-                        .join(" ")
-                }
+                Token::Literal(LiteralToken::Str(rcstrs)) => rcstrs
+                    .iter()
+                    .map(|rcstr| escape(rcstr.as_str()))
+                    .collect::<Vec<_>>()
+                    .join(" "),
+                Token::Literal(LiteralToken::Char(rcstr)) => escape(rcstr.as_str()),
                 other => other.to_string(),
             }
         })
         .collect();
-    Token::Literal(LiteralToken::Str(vec![RcStr::from(format!("\"{}\"", ret))]))
+    Token::Literal(LiteralToken::Str(vec![RcStr::from(format!(
+        "\"{}\"",
+        ret.trim()
+    ))]))
 }


### PR DESCRIPTION
This is an extension of branch in #437. I will rebase when that branch is merged.

Initial attempt seems to work for all cases except stringification of strings which contain escaped characters, in which case the escape is not deep enough. E.g.
```
#define f(a) #a
f("\n")
```
preprocesses to
```

"\"\n\""
```
but should be
```

"\"\\n\""
```