### PR TITLE
Skip whitespaces in preprocessor

### DIFF
--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -1647,7 +1647,9 @@ int main(){}
 
     #[test]
     fn space_separated_function_macro() {
-        let src = "#define f(a) <a>\nf     (a)";
-        assert_same(src, "<a>");
+        assert_same_exact("#define f(a) <a>\nf     (a)", "\n<a>");
+        assert_same_exact("#define f(a) <a>\nf(a)", "\n<a>");
+        assert_same_exact("#define f <a>\nf", "\n<a>");
+        assert_same_exact("#define f <a>\nf   ", "\n<a>   ");
     }
 }

--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -1653,6 +1653,7 @@ int main(){}
         assert_same_exact("#define f(a) <a>\nf   ", "\nf   ");
         assert_same_exact("#define f(a) <a>\nf   ;", "\nf   ;");
         assert_same_exact("#define f(a) <a>\nf;", "\nf;");
+        assert_same_exact("#define f(a) 1\n#define h f (2)\nh", "\n1");
     }
 
     #[test]

--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -1644,4 +1644,10 @@ int main(){}
         );
         // TODO test for #includes
     }
+
+    #[test]
+    fn space_separated_function_macro() {
+        let src = "#define f(a) <a>\nf     (a)";
+        assert_same(src, "<a>");
+    }
 }

--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -1649,7 +1649,20 @@ int main(){}
     fn space_separated_function_macro() {
         assert_same_exact("#define f(a) <a>\nf     (a)", "\n<a>");
         assert_same_exact("#define f(a) <a>\nf(a)", "\n<a>");
-        assert_same_exact("#define f <a>\nf", "\n<a>");
-        assert_same_exact("#define f <a>\nf   ", "\n<a>   ");
+        assert_same_exact("#define f(a) <a>\nf", "\nf");
+        assert_same_exact("#define f(a) <a>\nf   ", "\nf   ");
+        assert_same_exact("#define f(a) <a>\nf   ;", "\nf   ;");
+        assert_same_exact("#define f(a) <a>\nf;", "\nf;");
+    }
+
+    #[test]
+    fn eof_after_macro_call() {
+        use crate::data::lex::test::cpp_no_newline;
+
+        let cpp = cpp_no_newline("#define f(a)\nf")
+            .filter_map(|res| res.ok().map(|token| token.data.to_string()))
+            .collect::<Vec<_>>()
+            .join("");
+        assert_eq!(cpp, "\nf");
     }
 }

--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -1653,7 +1653,12 @@ int main(){}
         assert_same_exact("#define f(a) <a>\nf   ", "\nf   ");
         assert_same_exact("#define f(a) <a>\nf   ;", "\nf   ;");
         assert_same_exact("#define f(a) <a>\nf;", "\nf;");
-        assert_same_exact("#define f(a) 1\n#define h f (2)\nh", "\n1");
+        assert_same_exact(
+            "#define f(a) 1
+#define h f (2)
+h",
+            "\n\n1",
+        );
     }
 
     #[test]

--- a/src/lex/replace.rs
+++ b/src/lex/replace.rs
@@ -229,13 +229,16 @@ fn replace_function(
                 data: Token::Whitespace(_),
                 ..
             })) => {
-                let spaces = inner.next().unwrap();
+                let spaces = incoming.pop_front().or_else(|| inner.next()).unwrap();
+                let left_paren = incoming.front().or_else(|| inner.peek());
                 if let Some(Ok(Locatable {
                     data: Token::LeftParen,
                     ..
-                })) = inner.peek()
+                })) = left_paren
                 {
-                    inner.next();
+                    if incoming.pop_front().is_none() {
+                        inner.next();
+                    }
                     break;
                 }
                 let id_token = Ok(location.with(Token::Id(id)));
@@ -246,8 +249,8 @@ fn replace_function(
             // If this branch is matched, this is not a macro call,
             // since all other cases are covered above.
             // So just append the identifier and the current token to the stack.
-            Some(Ok(Locatable { data: _, .. })) => {
-                let token = inner.next().unwrap();
+            Some(Ok(_)) => {
+                let token = incoming.pop_front().or_else(|| inner.next()).unwrap();
                 let id_token = Ok(location.with(Token::Id(id)));
                 errors.push(id_token);
                 errors.push(token);

--- a/src/lex/replace.rs
+++ b/src/lex/replace.rs
@@ -212,6 +212,15 @@ fn replace_function(
                 // TODO: need to figure out what should happen if an error token happens during replacement
                 errors.push(Err(next.unwrap().unwrap_err()));
             }
+            // skip any whitespaces between `f` and `(`, so that
+            // `f (` is also valid.
+            Some(Ok(Locatable {
+                data: Token::Whitespace(_),
+                ..
+            })) => {
+                inner.next();
+                continue;
+            }
             // f (
             Some(Ok(Locatable {
                 data: Token::LeftParen,


### PR DESCRIPTION
This PR will skip any white spaces that occur in the `lex::replace::replace` method, to support macro calls where
the identifier and the arguments are separated by spaces (e.g. `f (`).

Resolves #457 