### PR TITLE
Fix macro redefinition semantics

### DIFF
--- a/src/data/error.rs
+++ b/src/data/error.rs
@@ -488,6 +488,11 @@ pub enum CppError {
     /// After parsing an `#if` expression, there were tokens left over.
     #[error("trailing tokens in `#if` expression")]
     TooManyTokens,
+
+    /// If a macro is redefined, its definition must be identical to as it's old
+    /// definition.
+    #[error("redefined macro definition for '{0}' does not match original definition")]
+    IncompatibleRedefinition(InternedStr),
 }
 
 /// Lex errors are non-exhaustive and may have new variants added at any time

--- a/src/data/error.rs
+++ b/src/data/error.rs
@@ -489,9 +489,9 @@ pub enum CppError {
     #[error("trailing tokens in `#if` expression")]
     TooManyTokens,
 
-    /// If a macro is redefined, its definition must be identical to as it's old
-    /// definition.
-    #[error("redefined macro definition for '{0}' does not match original definition")]
+    /// If a macro is redefined, the new definition must be identical to the
+    /// original.
+    #[error("redefinition of '{0}' does not match original definition")]
     IncompatibleRedefinition(InternedStr),
 }
 

--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -923,14 +923,32 @@ impl<'a> PreProcessor<'a> {
                 Vec::new()
             };
             let body = body(self)?;
-            self.definitions
-                .insert(id.data, Definition::Function { params, body });
+            self.define_macro(id.data, Definition::Function { params, body })
+                .map_err(|e| self.span(start).with(e))?;
             Ok(())
         } else {
             // object macro
             let tokens = body(self)?;
-            self.definitions.insert(id.data, Definition::Object(tokens));
+            self.define_macro(id.data, Definition::Object(tokens))
+                .map_err(|e| self.span(start).with(e))?;
             Ok(())
+        }
+    }
+    fn define_macro(&mut self, name: InternedStr, definition: Definition) -> Result<(), CppError> {
+        use std::collections::hash_map::Entry;
+        match self.definitions.entry(name) {
+            Entry::Vacant(entry) => {
+                entry.insert(definition);
+                Ok(())
+            }
+            Entry::Occupied(entry) => {
+                // https://port70.net/~nsz/c/c11/n1570.html#6.10.3p1
+                if entry.get() != &definition {
+                    Err(CppError::IncompatibleRedefinition(name))
+                } else {
+                    Ok(())
+                }
+            }
         }
     }
     // http://port70.net/~nsz/c/c11/n1570.html#6.10.2
@@ -1417,13 +1435,28 @@ a";
 #define a c
 a
 ";
-        assert_same(src, "c");
+        assert_err!(
+            src,
+            CppError::IncompatibleRedefinition(_),
+            "incompatible redfinition"
+        );
         let src = "
 #define a b
 #define a
 a
 ";
-        assert_same(src, "");
+        assert_err!(
+            src,
+            CppError::IncompatibleRedefinition(_),
+            "incompatible redefinition"
+        );
+
+        let src = "
+#define a b
+#define a b
+a
+";
+        assert_same(src, "b");
     }
     #[test]
     fn undef() {

--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -942,7 +942,7 @@ impl<'a> PreProcessor<'a> {
                 Ok(())
             }
             Entry::Occupied(entry) => {
-                // https://port70.net/~nsz/c/c11/n1570.html#6.10.3p1
+                // This behavior is defined by the spec in section 6.10.3p1
                 if entry.get() != &definition {
                     Err(CppError::IncompatibleRedefinition(name))
                 } else {
@@ -1457,6 +1457,35 @@ a
 a
 ";
         assert_same(src, "b");
+
+        let src = "
+#define a(b) b+1
+#define a(b) b+2
+a(2)
+";
+        assert_err!(
+            src,
+            CppError::IncompatibleRedefinition(_),
+            "incompatible redefinition"
+        );
+
+        let src = "
+#define a(b) b+1
+#define a(c) c+1
+a(2)
+";
+        assert_err!(
+            src,
+            CppError::IncompatibleRedefinition(_),
+            "incompatible redefinition"
+        );
+
+        let src = "
+#define a(b) b+1
+#define a(b) b+1
+a(2)        
+";
+        assert_same(src, "2+1");
     }
     #[test]
     fn undef() {

--- a/src/lex/replace.rs
+++ b/src/lex/replace.rs
@@ -48,7 +48,7 @@ impl<I: Peekable + ?Sized> Peekable for &mut I {
 }
 
 /// A macro definition.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Definition {
     /// An object macro: `#define a b + 1`
     Object(Vec<Token>),


### PR DESCRIPTION
Macro redefinition was broken. Added a new function to define macros for internal use and created an error for the erroneous macro redefinition.