### PR TITLE
Get rid of `first` argument to Parser::new

### DIFF
--- a/src/data/lex.rs
+++ b/src/data/lex.rs
@@ -286,11 +286,10 @@ impl AssignmentToken {
     }
 }
 
-#[cfg(test)]
 impl Default for Location {
     fn default() -> Self {
         let mut files = crate::Files::default();
-        let id = files.add("<test suite>", String::new().into());
+        let id = files.add("<default location>", String::new().into());
         Self {
             span: (0..1).into(),
             file: id,

--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -719,7 +719,6 @@ impl<'a> PreProcessor<'a> {
                 location,
             ));
         }
-        // TODO: remove(0) is bad and I should feel bad
         // TODO: this only returns the first error because anything else requires a refactor
         use crate::{analyze::PureAnalyzer, Parser};
         let mut parser = Parser::new(cpp_tokens.into_iter(), false);

--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -358,20 +358,6 @@ impl<'a> PreProcessor<'a> {
             file_processor,
         }
     }
-    /// Return the first valid token in the file,
-    /// or None if there are no valid tokens.
-    ///
-    /// In either case, return all invalid tokens found.
-    pub fn first_token(&mut self) -> (Option<Locatable<Token>>, VecDeque<CompileError>) {
-        let mut errs = VecDeque::new();
-        loop {
-            match self.next() {
-                Some(Ok(token)) => return (Some(token), errs),
-                Some(Err(err)) => errs.push_back(err),
-                None => return (None, errs),
-            }
-        }
-    }
 
     /// Return all warnings found so far.
     ///
@@ -712,7 +698,7 @@ impl<'a> PreProcessor<'a> {
             cpp_tokens.push(token);
         }
         let mut expr_location = None;
-        let mut cpp_tokens: Vec<_> = cpp_tokens
+        let cpp_tokens: Vec<_> = cpp_tokens
             .into_iter()
             .map(|t| replace(definitions, t.data, std::iter::empty(), t.location))
             .flatten()
@@ -735,9 +721,8 @@ impl<'a> PreProcessor<'a> {
         }
         // TODO: remove(0) is bad and I should feel bad
         // TODO: this only returns the first error because anything else requires a refactor
-        let first = cpp_tokens.remove(0)?;
         use crate::{analyze::PureAnalyzer, Parser};
-        let mut parser = Parser::new(first, cpp_tokens.into_iter(), false);
+        let mut parser = Parser::new(cpp_tokens.into_iter(), false);
         let expr = parser.expr()?;
         if !parser.is_empty() {
             return Err(CompileError::new(


### PR DESCRIPTION
This made things much more difficult and inconsistent, for no real benefit.

The major change is that the initial location is now a dummy location,
instead of being a real location that could be printed. Since the very
initial location will always be overwritten by the first token seen, this
should not cause any change in behavior.

Additionally, `Location::default` is now a public method. This is not ideal, but shouldn't hurt anything.

This makes #475 simpler, since the parser can now treat the `tokens` as the only source of tokens.