### PR TITLE
Get rid of unput in the lexer

### DIFF
--- a/src/lex/mod.rs
+++ b/src/lex/mod.rs
@@ -151,26 +151,7 @@ impl Lexer {
         self.lookahead = self.lookahead.or_else(|| self.chars().nth(1));
         self.lookahead
     }
-    /// Return a single token to the stream.
-    /// Can be called at most once before running out of space to store the token.
-    ///
-    /// # Panics
-    /// This function will panic if called twice in a row
-    /// or when `self.lookahead.is_some()`.
-    fn unput(&mut self, byte: char) {
-        assert!(
-            self.lookahead.is_none(),
-            "unputting {:?} would cause the lexer to forget it saw {:?} (current is {:?})",
-            byte as char,
-            self.lookahead.unwrap() as char,
-            self.current.unwrap() as char
-        );
-        self.lookahead = self.current.take();
-        self.current = Some(byte);
-        // TODO: this is not right,
-        // it will break if someone calls `span()` before consuming the newline
-        self.location.offset -= 1;
-    }
+
     /// If the next character is `item`, consume it and return true.
     /// Otherwise, return false.
     fn match_next(&mut self, item: char) -> bool {
@@ -627,18 +608,14 @@ impl Lexer {
             Err(CharError::MultiByte) => Err(LexError::MultiByteCharLiteral),
         }
     }
-    /// Parse a string literal, starting before the opening quote.
+    /// Parse a string literal, starting after the opening quote.
     ///
-    /// Concatenates multiple adjacent literals into one string.
     /// Adds a terminating null character, even if a null character has already been found.
     ///
-    /// Before: u8s{"hello" "you" "it's me" mary}
-    /// After:  chars{mary}
+    /// Before: chars{hello" "you"}
+    /// After:  chars{ "you"}
     fn parse_string(&mut self) -> Result<Token, LexError> {
         let mut literal = Vec::new();
-        // allow multiple adjacent strings
-        //while self.peek() == Some(b'"') {
-        self.next_char(); // start quote
         loop {
             match self.parse_single_char(true) {
                 Ok(c) => literal.push(c),
@@ -658,22 +635,7 @@ impl Lexer {
                 }
             }
         }
-        /*
-        let old_saw_token = self.seen_line_token;
-        self.consume_whitespace();
-        // we're in a quandry here: we saw a newline, which reset `seen_line_token`,
-        // but we're about to return a string, which will mistakenly reset it again.
-        // HACK: `unput()` a newline, so that we'll reset `seen_line_token` again
-        // HACK: on the following call to `next()`.
-        // NOTE: since we saw a newline, we must have consumed at least one token,
-        // NOTE: so this can't possibly discard `self.lookahead`.
-        if self.seen_line_token != old_saw_token && self.peek() != Some(b'"') {
-            self.unput(b'\n');
-        }
-        */
-        //}
 
-        
         literal.push(b'\0');
         Ok(Literal::Str(literal).into())
     }
@@ -932,16 +894,13 @@ impl Iterator for Lexer {
                         return Some(Err(span.with(err)));
                     }
                 },
-                '"' => {
-                    self.unput('"');
-                    match self.parse_string() {
-                        Ok(id) => id,
-                        Err(err) => {
-                            let span = self.span(span_start);
-                            return Some(Err(span.with(err)));
-                        }
+                '"' => match self.parse_string() {
+                    Ok(id) => id,
+                    Err(err) => {
+                        let span = self.span(span_start);
+                        return Some(Err(span.with(err)));
                     }
-                }
+                },
                 x => {
                     return Some(Err(self
                         .span(span_start)

--- a/src/parse/expr.rs
+++ b/src/parse/expr.rs
@@ -372,7 +372,7 @@ impl<I: Lexer> Parser<I> {
 }
 
 #[cfg(test)]
-mod test {
+pub(crate) mod test {
     use super::SyntaxResult;
     use crate::data::ast::{Expr, ExprType};
     use crate::parse::test::*;
@@ -388,7 +388,7 @@ mod test {
         assert_eq!(expr(left).unwrap().to_string(), right);
     }
 
-    fn expr(e: &str) -> SyntaxResult<Expr> {
+    pub(crate) fn expr(e: &str) -> SyntaxResult<Expr> {
         parser(e).expr()
     }
 

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -137,8 +137,6 @@ impl<I: Lexer> Parser<I> {
     }
     // don't use this, use next_token instead
     fn __impl_next_token(&mut self) -> Option<Locatable<Token>> {
-        // needed for string concatenation
-        assert!(self.current.is_none() || self.next.is_none());
         loop {
             match self.tokens.next() {
                 Some(Ok(Locatable {


### PR DESCRIPTION
- Move string concatenation to the parser
- Use std::iter::peekable to see if the next token is a string or not
- Don't consume the leading `"` of a string token in `parse_string`
- Get rid of `unput()` in the lexer

r? @hdamron17 