### PR TITLE
Close #453. Builtin macros such as `__LINE__` (not function macros like `__has_header()`)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ git-testament = { version = "0.1", optional = true }
 rand = { version = "0.7", optional = true }
 rodio = { version = "0.11.0", optional = true }
 shared_str = "0.1.1"
+time = "0.2"
 
 [dev-dependencies]
 env_logger = { version = "0.7", default-features = false }

--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -1169,8 +1169,8 @@ impl<'a> PreProcessor<'a> {
 fn int_def(i: i32) -> Definition {
     Definition::Object(vec![LiteralToken::Int(RcStr::from(i.to_string())).into()])
 }
-fn str_def<S: ToString>(s: S) -> Definition {
-    let rcstr = RcStr::from(format!("\"{}\"", s.to_string().replace(r#"""#, r#"\""#)));
+fn str_def<S: Into<String>>(s: S) -> Definition {
+    let rcstr = RcStr::from(format!("\"{}\"", s.into().replace(r#"""#, r#"\""#)));
     Definition::Object(vec![LiteralToken::Str(vec![rcstr]).into()])
 }
 

--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -1161,7 +1161,7 @@ impl<'a> PreProcessor<'a> {
     fn update_builtin_definitions(&mut self) {
         self.definitions.extend(map! {
             "__LINE__".into() => int_def((self.line() + 1) as i32),
-            "__FILE__".into() => str_def(self.file_processor.path().to_str().unwrap()),  // Fails if non-Unicode
+            "__FILE__".into() => str_def(self.file_processor.path().to_string_lossy()),
         })
     }
 }
@@ -1169,8 +1169,8 @@ impl<'a> PreProcessor<'a> {
 fn int_def(i: i32) -> Definition {
     Definition::Object(vec![LiteralToken::Int(RcStr::from(i.to_string())).into()])
 }
-fn str_def(s: &str) -> Definition {
-    let rcstr = RcStr::from(format!("\"{}\"", s));
+fn str_def<S: ToString>(s: S) -> Definition {
+    let rcstr = RcStr::from(format!("\"{}\"", s.to_string().replace(r#"""#, r#"\""#)));
     Definition::Object(vec![LiteralToken::Str(vec![rcstr]).into()])
 }
 

--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -340,7 +340,6 @@ impl<'a> PreProcessor<'a> {
             "__STDC_NO_COMPLEX__".into() => int_def(1),
             "__STDC_NO_THREADS__".into() => int_def(1),
             "__STDC_NO_VLA__".into() => int_def(1),
-            "__STDC_IEC_559__".into() => int_def(1),
             "__DATE__".into() => str_def(&now.format("%b %_d %Y")),
             "__TIME__".into() => str_def(&now.format("%H:%M:%S")),
         };


### PR DESCRIPTION
This will provide the functionality to define builtin macros. Those in #453 and `__has_header()` will be implemented as proof of concept.