### PR TITLE
Close #449. Allow replacement of function macros in `#if`

### DIFF
--- a/src/lex/replace.rs
+++ b/src/lex/replace.rs
@@ -79,7 +79,7 @@ pub struct Replace<'a, I: Iterator> {
     definitions: &'a Definitions,
 }
 
-pub fn replace_iter<'a, I: Iterator>(iter: I, definitions: &'a Definitions) -> Replace<'a, I> {
+pub fn replace_iter<I: Iterator>(iter: I, definitions: &Definitions) -> Replace<'_, I> {
     Replace {
         iter: iter.peekable(),
         definitions,

--- a/src/lex/replace.rs
+++ b/src/lex/replace.rs
@@ -74,6 +74,35 @@ pub enum Definition {
     },
 }
 
+pub struct Replace<'a, I: Iterator> {
+    iter: std::iter::Peekable<I>,
+    definitions: &'a Definitions,
+}
+
+pub fn replace_iter<'a, I: Iterator>(iter: I, definitions: &'a Definitions) -> Replace<'a, I> {
+    Replace {
+        iter: iter.peekable(),
+        definitions,
+    }
+}
+
+impl<I: Iterator<Item = CompileResult<Locatable<Token>>>> Iterator for Replace<'_, I> {
+    type Item = Vec<CompileResult<Locatable<Token>>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.iter.next() {
+            Some(Ok(t)) => Some(replace(
+                self.definitions,
+                t.data,
+                &mut self.iter,
+                t.location,
+            )),
+            Some(Err(err)) => Some(vec![Err(err)]),
+            None => None,
+        }
+    }
+}
+
 /// Perform recursive macro replacement on `token`.
 ///
 /// This first performs object-macro replacement, then function-macro replacement.


### PR DESCRIPTION
Close #449. This implements a `replace_iter` function which applies `replace` to the iterator, allowing replacement of function macros in `#if`.