### PR TITLE
Don't emit further type errors if already encountered type error

### DIFF
--- a/src/analyze/expr.rs
+++ b/src/analyze/expr.rs
@@ -667,7 +667,8 @@ impl PureAnalyzer {
             // i[p]
             (_, Type::Pointer(target, _)) => ((**target).clone(), right, left),
             // already type error
-            (Type::Error, _) | (_, Type::Error) => return left,
+            (Type::Error, _) => return left,
+            (_, Type::Error) => return right,
             (l, _) => {
                 self.err(SemanticError::NotAPointer(l.clone()), location);
                 return left;

--- a/tests/runner-tests/decls/test_initializers/8.c
+++ b/tests/runner-tests/decls/test_initializers/8.c
@@ -1,4 +1,4 @@
-// errors: 8
+// errors: 5
 void i = {1};
 void i = 1;
 int a[](*fp)() = {0};


### PR DESCRIPTION
This fixes #458 by checking for `Type::Error` before reporting other errors. Also undeclared identifiers are now set to be `lval`s.

Not sure if my code is the most idiomatic / if I got all cases, but helped to get a better understanding of the analyzer.

