### PR TITLE
Have {-h, --help} flags return 0

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -292,10 +292,10 @@ fn parse_args() -> Result<(BinOpt, PathBuf), pico_args::Error> {
     let mut input = Arguments::from_env();
     if input.contains("-h") {
         println!("{}", USAGE);
-        std::process::exit(1);
+        std::process::exit(0);
     } else if input.contains("--help") {
         println!("{}", HELP);
-        std::process::exit(1);
+        std::process::exit(0);
     }
     if input.contains(["-V", "--version"]) {
         #[cfg(feature = "git-testament")]


### PR DESCRIPTION
Have the binary return 0 instead of 1 when the `-h` or `--help` flag is used. This is what a lot of *nix commands do.
