### PR TITLE
Convert code from shared_string to arcstr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ atty = { version = "0.2", default-features = false, optional = true }
 git-testament = { version = "0.1", optional = true }
 rand = { version = "0.7", optional = true }
 rodio = { version = "0.11.0", optional = true }
-shared_str = "0.1.1"
+arcstr = "0.2.2"
 time = "0.2"
 
 [dev-dependencies]

--- a/benches/parens.rs
+++ b/benches/parens.rs
@@ -1,16 +1,16 @@
+use arcstr::ArcStr;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rcc::codespan::Files;
 use rcc::{Lexer, Locatable, Parser, Token};
-use std::rc::Rc;
 
 fn parens(c: &mut Criterion) {
     // should take no more than n stack frames
     let n = 3000;
-    let the_biggun = Rc::from(format!("{}1 + 2{}", "(".repeat(n), ")".repeat(n)));
+    let the_biggun = arcstr::format!("{}1 + 2{}", "(".repeat(n), ")".repeat(n));
     let parse = |s| {
         let mut files = Files::new();
-        let file_id = files.add("<bench>", Rc::clone(s));
-        let mut lexer = Lexer::new(file_id, Rc::clone(s), false);
+        let file_id = files.add("<bench>", ArcStr::clone(s));
+        let mut lexer = Lexer::new(file_id, ArcStr::clone(s), false);
         let first: Locatable<Token> = lexer.next().unwrap().unwrap();
         let mut p: Parser<Lexer> = Parser::new(first, lexer, false);
         p.expr()

--- a/src/data/lex.rs
+++ b/src/data/lex.rs
@@ -7,7 +7,7 @@ use proptest_derive::Arbitrary;
 use crate::data::hir::BinaryOp;
 use crate::intern::InternedStr;
 
-use shared_str::RcStr;
+use arcstr::Substr;
 
 // holds where a piece of code came from
 // should almost always be immutable
@@ -166,11 +166,11 @@ pub enum ComparisonToken {
 #[derive(Clone, Debug)]
 pub enum LiteralToken {
     // literals
-    Int(RcStr),
-    UnsignedInt(RcStr),
-    Float(RcStr),
-    Str(Vec<RcStr>),
-    Char(RcStr),
+    Int(Substr),
+    UnsignedInt(Substr),
+    Float(Substr),
+    Str(Vec<Substr>),
+    Char(Substr),
 }
 
 impl PartialEq for LiteralToken {
@@ -404,15 +404,15 @@ impl std::fmt::Display for LiteralToken {
             Int(i) => write!(f, "{}", i),
             UnsignedInt(u) => write!(f, "{}", u),
             Float(n) => write!(f, "{}", n),
-            Str(rcstr) => {
-                let joined = rcstr
-                    .iter()
-                    .map(RcStr::as_str)
-                    .collect::<Vec<_>>()
+            Str(s) => {
+                let joined = s
+                    // .iter()
+                    // .map(Substr::as_str)
+                    // .collect::<Vec<_>>()
                     .join(" ");
                 write!(f, "{}", joined)
             }
-            Char(rcstr) => write!(f, "{}", rcstr.as_str()),
+            Char(s) => write!(f, "{}", s),
         }
     }
 }
@@ -463,8 +463,8 @@ impl From<ComparisonToken> for Token {
 #[cfg(test)]
 mod proptest_impl {
     use super::LiteralToken;
+    use arcstr::Substr;
     use proptest::prelude::*;
-    use shared_str::RcStr;
 
     impl Arbitrary for LiteralToken {
         type Parameters = ();
@@ -472,19 +472,19 @@ mod proptest_impl {
         fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
             prop_oneof![
                 // TODO give regex of all possible literals
-                any::<i64>().prop_map(|x| LiteralToken::Int(RcStr::from(x.to_string()))),
-                any::<u64>().prop_map(|x| LiteralToken::UnsignedInt(RcStr::from(x.to_string()))),
-                any::<f64>().prop_map(|x| LiteralToken::Float(RcStr::from(x.to_string()))),
-                any::<u8>().prop_map(|c| LiteralToken::Char(RcStr::from(format!(
+                any::<i64>().prop_map(|x| LiteralToken::Int(Substr::from(x.to_string()))),
+                any::<u64>().prop_map(|x| LiteralToken::UnsignedInt(Substr::from(x.to_string()))),
+                any::<f64>().prop_map(|x| LiteralToken::Float(Substr::from(x.to_string()))),
+                any::<u8>().prop_map(|c| LiteralToken::Char(Substr::from(arcstr::format!(
                     "\'{}\'",
                     (c as char).escape_default()
                 )))),
                 prop::collection::vec(".*", 1..10).prop_map(|strs| {
-                    let rcstrs = strs
+                    let substrs = strs
                         .into_iter()
-                        .map(|s| RcStr::from(format!("\"{}\"", s.escape_default())))
+                        .map(|s| Substr::from(arcstr::format!("\"{}\"", s.escape_default())))
                         .collect();
-                    LiteralToken::Str(rcstrs)
+                    LiteralToken::Str(substrs)
                 }),
             ]
             .boxed()

--- a/src/data/lex.rs
+++ b/src/data/lex.rs
@@ -404,14 +404,7 @@ impl std::fmt::Display for LiteralToken {
             Int(i) => write!(f, "{}", i),
             UnsignedInt(u) => write!(f, "{}", u),
             Float(n) => write!(f, "{}", n),
-            Str(s) => {
-                let joined = s
-                    // .iter()
-                    // .map(Substr::as_str)
-                    // .collect::<Vec<_>>()
-                    .join(" ");
-                write!(f, "{}", joined)
-            }
+            Str(s) => write!(f, "{}", s.join(" ")),
             Char(s) => write!(f, "{}", s),
         }
     }

--- a/src/lex/files.rs
+++ b/src/lex/files.rs
@@ -4,8 +4,8 @@ use crate::{
     ErrorHandler, Location,
 };
 use crate::{Files, Source};
+use arcstr::ArcStr;
 use std::path::{Path, PathBuf};
-use std::rc::Rc;
 
 // TODO: this API is absolutely terrible, there's _no_ encapsulation
 pub(super) struct FileProcessor {
@@ -49,7 +49,7 @@ impl Iterator for FileProcessor {
 
 impl FileProcessor {
     pub(super) fn new(
-        chars: impl Into<Rc<str>>,
+        chars: impl Into<ArcStr>,
         filename: impl Into<std::ffi::OsString>,
         debug: bool,
     ) -> Self {
@@ -57,7 +57,7 @@ impl FileProcessor {
         let chars = chars.into();
         let filename = filename.into();
         let source = crate::Source {
-            code: Rc::clone(&chars),
+            code: ArcStr::clone(&chars),
             path: filename.clone().into(),
         };
         let file = files.add(filename, source);
@@ -87,7 +87,7 @@ impl FileProcessor {
         self.includes.last_mut().unwrap_or(&mut self.first_lexer)
     }
     pub(super) fn add_file(&mut self, filename: PathBuf, source: Source) {
-        let code = Rc::clone(&source.code);
+        let code = ArcStr::clone(&source.code);
         let id = self.files.add(filename, source);
         self.includes
             .push(Lexer::new(id, code, self.first_lexer.debug));

--- a/src/lex/mod.rs
+++ b/src/lex/mod.rs
@@ -1059,3 +1059,23 @@ impl LiteralToken {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::Lexer;
+    use arcstr::ArcStr;
+    #[test]
+    fn test_lexer_slice_parent() {
+        let mut files = codespan::Files::new();
+        let astr = arcstr::literal!("int main() { return 0; }\n");
+        let dummy_id = files.add("dummy main", ArcStr::clone(&astr));
+        let mut lexer = Lexer::new(dummy_id, &astr, false);
+        let _ = lexer.next();
+        let sliced = lexer.slice(0);
+        // Note that the parent is not guaranteed to be equal for empty strings,
+        // since we don't want to have an empty substr which is the last
+        // remaining thing keeping some non-empty ArcStr from being freed.
+        assert!(!sliced.is_empty(), "{:?}", sliced);
+        assert!(ArcStr::ptr_eq(sliced.parent(), &astr));
+    }
+}

--- a/src/lex/replace.rs
+++ b/src/lex/replace.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use std::collections::{HashMap, HashSet, VecDeque};
 
-use shared_str::RcStr;
+use arcstr::Substr;
 
 /// All known macro definitions.
 ///
@@ -434,7 +434,7 @@ fn stringify(args: Vec<Token>) -> Token {
             }
         })
         .collect();
-    Token::Literal(LiteralToken::Str(vec![RcStr::from(format!(
+    Token::Literal(LiteralToken::Str(vec![Substr::from(arcstr::format!(
         "\"{}\"",
         ret.trim()
     ))]))

--- a/src/lex/tests.rs
+++ b/src/lex/tests.rs
@@ -2,7 +2,7 @@ use super::{CompileResult, LiteralToken, Locatable, Token};
 use crate::data::hir::LiteralValue;
 use crate::data::lex::test::{cpp, cpp_no_newline};
 use crate::intern::InternedStr;
-use shared_str::RcStr;
+use arcstr::Substr;
 
 type LexType = CompileResult<Locatable<Token>>;
 
@@ -171,24 +171,24 @@ fn test_float_literals() {
     for i in 0..10 {
         assert_float(&format!("1{}e{}", "0".repeat(i), 10 - i), 1e10);
     }
-    fn rcstr<S: ToString>(x: S) -> RcStr {
-        RcStr::from(x.to_string())
+    fn substr<S: ToString>(x: S) -> Substr {
+        Substr::from(x.to_string())
     }
     assert!(match_all(
         &lex_all("-1"),
-        &[Token::Minus, LiteralToken::Int(rcstr(1)).into()]
+        &[Token::Minus, LiteralToken::Int(substr(1)).into()]
     ));
     assert!(match_all(
         &lex_all("-1e10"),
         &[
             Token::Minus,
-            LiteralToken::Float(rcstr(10_000_000_000.0)).into()
+            LiteralToken::Float(substr(10_000_000_000.0)).into()
         ]
     ));
     assert!(match_data(lex("9223372036854775807u"), |lexed| {
         match_data_eq(
             lexed.unwrap(),
-            &LiteralToken::UnsignedInt(rcstr(9_223_372_036_854_775_807u64)).into(),
+            &LiteralToken::UnsignedInt(substr(9_223_372_036_854_775_807u64)).into(),
         )
     }));
     assert_float("0x.ep0", 0.875);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,8 @@ compile_error!(concat!(
     "` binary."
 ));
 
+use arcstr::ArcStr;
+
 /// The `Source` type for `codespan::Files`.
 ///
 /// Used to store extra metadata about the file, like the absolute filename.
@@ -36,7 +38,7 @@ compile_error!(concat!(
 /// since it does not adhere to the C standard.
 #[derive(Debug, Clone)]
 pub struct Source {
-    pub code: Rc<str>,
+    pub code: ArcStr,
     pub path: PathBuf,
 }
 
@@ -356,16 +358,16 @@ mod jit {
         }
     }
 
-    impl TryFrom<Rc<str>> for JIT {
+    impl TryFrom<ArcStr> for JIT {
         type Error = Error;
-        fn try_from(source: Rc<str>) -> Result<JIT, Self::Error> {
+        fn try_from(source: ArcStr) -> Result<JIT, Self::Error> {
             JIT::from_string(source, Opt::default()).result
         }
     }
 
     impl JIT {
         /// Compile string and return JITed code.
-        pub fn from_string<R: Into<Rc<str>>>(source: R, opt: Opt) -> Program<Self, Error> {
+        pub fn from_string<R: Into<ArcStr>>(source: R, opt: Opt) -> Program<Self, Error> {
             let source = source.into();
             let module = initialize_jit_module();
             let program = compile(module, &source, opt);
@@ -444,7 +446,7 @@ mod jit {
     }
 }
 
-impl<T: Into<Rc<str>>> From<T> for Source {
+impl<T: Into<ArcStr>> From<T> for Source {
     fn from(src: T) -> Self {
         Self {
             code: src.into(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,10 +4,10 @@ use std::io::{self, Read};
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::process;
-use std::rc::Rc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use ansi_term::{ANSIString, Colour};
+use arcstr::ArcStr;
 use pico_args::Arguments;
 use saltwater::{
     assemble, compile,
@@ -116,7 +116,7 @@ macro_rules! sw_try {
 
 // TODO: when std::process::termination is stable, make err_exit an impl for CompileError
 // TODO: then we can move this into `main` and have main return `Result<(), Error>`
-fn real_main(buf: Rc<str>, bin_opt: BinOpt, output: &Path) -> Result<(), (Error, Files)> {
+fn real_main(buf: ArcStr, bin_opt: BinOpt, output: &Path) -> Result<(), (Error, Files)> {
     let opt = if bin_opt.preprocess_only {
         use std::io::{BufWriter, Write};
 
@@ -266,7 +266,7 @@ fn main() {
             });
         opt.opt.filename
     };
-    let buf: Rc<_> = buf.into();
+    let buf: ArcStr = buf.into();
     let max_errors = opt.opt.max_errors;
     let color_choice = opt.color;
     real_main(buf, opt, &output)


### PR DESCRIPTION
You asked me to in https://github.com/thomcc/arcstr/issues/13#issuecomment-674550811 and it's a good excuse to test out the API of ArcStr and make sure there are no gaps.

Note that arcstr's types show up in the public API as `Into<ArcStr>`, whereas shared_string did not, since we don't use `Arc<str>`/`Rc<str>` under the hood. Without without this you'd essentially have no reason to use `arcstr` as each substr would be independent (actually, there are probably ways around this if you really need it but it would require additional string copies).

Also note that your benchmarks don't compile for me with or without these changes. I'll see if the fix is trivial but if not will leave it to y'all.

Also the tests fail for me with and without these changes because someone somewhere can't find `puts`. Maybe my `stdio.h` is weird or something idk.