### PR TITLE
Run clippy on non-default features, too

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -428,7 +428,7 @@ fn error<T: std::fmt::Display>(msg: T, location: Location, file_db: &Files, colo
     let err = {
         use rand::Rng;
 
-        let name = std::env::var("USER").unwrap_or("programmer".into());
+        let name = std::env::var("USER").unwrap_or_else(|_| "programmer".into());
         shut_up = format!("Shut up, {}. I don't ever want to hear that kind of obvious garbage and idiocy from a developer again", name);
         let msgs = [
             "you can't write code",

--- a/tests/pre-commit.sh
+++ b/tests/pre-commit.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 set -ev
 cargo fmt --all -- --check
-cargo clippy --all -- -D clippy::all -D unused-imports
+cargo clippy --all --all-features -- -D clippy::all -D unused-imports
 cargo test --all --all-features

--- a/tests/runner-tests/hello_world.c
+++ b/tests/runner-tests/hello_world.c
@@ -1,4 +1,4 @@
-#include<stdio.h>
+int puts(const char *);
 
 int main() {
     puts("Hello, world!");


### PR DESCRIPTION
This fixes the CI failure in https://github.com/jyn514/saltwater/pull/515#issuecomment-691684770 and is generally good practice.